### PR TITLE
fix: 修复megalo build后在真机上图表不显示的问题

### DIFF
--- a/src/echarts.vue
+++ b/src/echarts.vue
@@ -3,11 +3,11 @@
     v-if="canvasId"
     class="ec-canvas"
     :id="canvasId"
-    :canvasId="canvasId"
+    :canvas-id="canvasId"
     @touchstart="touchStart"
     @touchmove="touchMove"
     @touchend="touchEnd"
-    @error="error">
+    @error="$emit('error', arguments[0])">
   </canvas>
 </template>
 


### PR DESCRIPTION
1. 微信小程序canvas的canvas id属性必须是canvas-id，而不是canvasId
2. @error="error"处使用的error方法没有定义，可以改成直接$emit('error', arguments[0])让使用者决定怎么处理error